### PR TITLE
Add `viewBox` attribute to Icon.svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can configure icons props using
   }
 </style>
 
-<Icon src={AiOutlineNodeExpand} color="red" size="64" className="custom-icon" title="Custom icon params" />
+<Icon src={AiOutlineNodeExpand} color="red" size="64" viewBox="0 0 1024 1024" className="custom-icon" title="Custom icon params" />
 ```
 
 | Key         | Default               | Notes                              |
@@ -75,8 +75,9 @@ You can configure icons props using
 | `src`       | `SvgIcon`             |                                    |
 | `color`     | `undefined` (inherit) |                                    |
 | `size`      | `1em`                 |                                    |
+| `viewBox`   | `undefined`           | SVG [`viewBox`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox) attribute used if the underlying icon set does nots specify a `viewBox` per SVG. |
 | `className` | `undefined`           |                                    |
-| `title`     | `undefined`           | Icon description for accessibility |
+| `title`     | `undefined`           | Icon description for accessibility. |
 
 ## Licence
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -258,6 +258,7 @@ async function generateSvelteIconComponent() {
     `<script>
 export let src;
 export let size = "1em";
+export let viewBox = undefined;
 export let color = undefined;
 export let title = undefined;
 export let className = "";
@@ -284,6 +285,7 @@ $: {
 <svg
 width={size}
 height={size}
+viewBox={viewBox}
 stroke-width="0"
 class={className}
 {...src.a}


### PR DESCRIPTION
Some icon sets do not supply a `viewBox` attribute on their SVGs. This change allows the caller of `<Icon ... />` to specify a custom `viewBox` such that icon scaling works correctly when using a non-native icon size.